### PR TITLE
RK: Fix Typos

### DIFF
--- a/notebooks/02_TimeIntegration/02_02_RungeKutta.md
+++ b/notebooks/02_TimeIntegration/02_02_RungeKutta.md
@@ -93,7 +93,7 @@ In notebook 1.1, we discussed the fact that the forward Euler method is second-o
          & = y^n + dt y'^n + \frac{dt^2}{2}y''^n + O(dt^3), \label{TaylorRK2}
 \end{align}
 
-where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third-order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
+where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third-order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two-stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
 
 ### Numerical stability of a two-stage Runge-Kutta scheme
 
@@ -111,7 +111,7 @@ Using the two-stage Runge-Kutta scheme, we then have,
     z^{n} = (I+ dt \Lambda + \frac{dt^2}{2}\Lambda^2) z^{n-1} \; \Leftrightarrow \; z^{n} = (I+ dt \Lambda + \frac{dt^2}{2}\Lambda^2)^n z^0.
 \end{equation}
 
-All the components of $z^{n}$ will remain finite for $n\rightarrow \infty$ as long as the following relation is satisified for all the eigenvalues $\lambda_k$:
+All the components of $z^{n}$ will remain finite for $n\rightarrow \infty$ as long as the following relation is satisfied for all the eigenvalues $\lambda_k$:
 
 \begin{equation}
     \vert 1+\lambda_k dt + \frac{\lambda_k^2 dt^2}{2} \vert \leq 1.
@@ -251,7 +251,7 @@ General Runge-Kutta schemes are defined as follows \cite{Hairer1987}:
 
 Some constraints are then put on all the coefficients to achieve a given order of accuracy $O(dt^p)$ for $y^{n+1}$. One says that the $s$-stage Runge-Kutta method is of order $p$.
 
-The construction of higher-order Runge-Kutta schemes is in fact quite complicated, and has been the subject of a vast literature (some in depth review of the Runge-Kutta methods may be found in \cite{Butcher2008} or \cite{Hairer1987}). There is no systematic way to obtain order $p$ methods with a minimum number of stages $s$. One can achieve order $p$ with $s=p$ up to $p=4$. For $p=5$ and $p=6$ one needs at least $s=p+1$ stages. For $p=7$ and $p=8$ the minimum number of stages are respectively $s=9$ and $s=11$.
+The construction of higher-order Runge-Kutta schemes is in fact quite complicated, and has been the subject of a vast literature (some in-depth review of the Runge-Kutta methods may be found in \cite{Butcher2008} or \cite{Hairer1987}). There is no systematic way to obtain order $p$ methods with a minimum number of stages $s$. One can achieve order $p$ with $s=p$ up to $p=4$. For $p=5$ and $p=6$ one needs at least $s=p+1$ stages. For $p=7$ and $p=8$ the minimum number of stages are respectively $s=9$ and $s=11$.
 
 > Above this, very little is known \cite{Butcher1996}.
 
@@ -285,7 +285,7 @@ In the following plot, we compare the regions of stability for the various schem
 
 ```python
 # As before, the x-axis corresponds to
-# lambda_i*dt and the y-axis to lambda_r*dt.
+# lambda_r*dt and the y-axis to lambda_i*dt.
 # We set the resolution along x and y
 # (in points per the whole 1D domain).
 nx = 100
@@ -445,7 +445,7 @@ Generally speaking, RK methods can be defined as follows:
 & k_i = f(t^n + c_i dt, y^n + dt\sum_{j=1}^h a_{ij} k_j).
 \end{align}
 
-For explicit RK methods one has $h=s-1$. This implies that any $k_i$ can be computed explicitly from the knowledge of the previously computed $k_j$ with $j<i$. For implicit RK methods, we have $h=s$. It mean, that for each $k_i$ we have to solve an implicit equation $k_i=f(k_1, k_2,\dots,k_i)$. We pay a price in terms of complexity (we have to invert some matrix or iteratively found a solution to the previous equation). However, implicit RK methods have better stability properties compared to explicit ones and can therefore be used for a larger set of problems.
+For explicit RK methods one has $h=s-1$. This implies that any $k_i$ can be computed explicitly from the knowledge of the previously computed $k_j$ with $j<i$. For implicit RK methods, we have $h=s$. It mean, that for each $k_i$ we have to solve an implicit equation $k_i=f(k_1, k_2,\dots,k_i)$. We pay a price in terms of complexity (we have to invert some matrix or iteratively find a solution to the previous equation). However, implicit RK methods have better stability properties compared to explicit ones and can therefore be used for a larger set of problems.
 
 As an example, let us consider some relatively simple implicit RK scheme - we went on [Wikipedia][1] and picked one named *Qin and Zhang's two-stage second-order* implicit method. It reads:
 
@@ -545,7 +545,7 @@ for axis in ax:
 
 In this notebook we have introduced a family of Runge-Kutta explicit and implicit methods. While we won't consider Runge-Kutta schemes of order higher than 4 in the course, we discussed the complexities one would face trying to construct equations for the coefficients $k_i$ for higher-order schemes. We also gave insight into implicit Runge-Kutta schemes and provided an implementation of Qin and Zhang's second-order implicit method.
 
-With this we conclude the chapter dedicated to **Time integration**. In the following chapter we will consider the finite differences method to approximate derivatives in partial differential equations and convert them into a system of linear equations.
+With this we conclude the chapter dedicated to **time integration**. In the following chapter we will consider the finite differences method to approximate derivatives in partial differential equations and convert them into a system of linear equations.
 
 ## Exercises
 

--- a/notebooks/02_TimeIntegration/02_02_RungeKutta.md
+++ b/notebooks/02_TimeIntegration/02_02_RungeKutta.md
@@ -273,7 +273,7 @@ For an autonomous linear system, it is straightforward to prove that this method
   & = z^n + dt \Lambda z^n + \frac{dt^2}{2}\Lambda^2 z^n + \frac{dt^3}6 \Lambda^3 z^n + \frac{dt^4}{24} \Lambda^4 z^n
 \end{align}
 
-The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth order. For a non-linear system, one can also prove that RK4 is of fourth-order but it is a tedious task.
+The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth order. For a non-linear system, one can also prove that RK4 is of fourth order but it is a tedious task.
 
 In terms of stability, we also see that the RK4 method is stable for a general autonomous linear system as long as all the eigenvalues of the operator $f$ satisfy,
 

--- a/notebooks/02_TimeIntegration/02_02_RungeKutta.md
+++ b/notebooks/02_TimeIntegration/02_02_RungeKutta.md
@@ -58,7 +58,7 @@ Here we introduce some more accurate methods with larger domains of stability, t
 
 where $y$ and $f$ are vector valued functions.
 
-## A two stage Runge-Kutta scheme
+## A two-stage Runge-Kutta scheme
 
 The forward Euler method is defined through:
 
@@ -74,7 +74,7 @@ Graphically, we see that $y^{n+1}$ is evaluated using the value $y^n$ and the sl
 
 Runge-Kutta schemes increase the accuracy of the estimated value $y^{n+1}$ by introducing intermediate times between $t^n$ and $t^{n+1}$, at which the derivative of $y$ is evaluated and by making use of this information.
 
-The following two stage Runge-Kutta method is the simplest of such schemes. Graphically, this scheme is defined as follows:
+The following two-stage Runge-Kutta method is the simplest of such schemes. Graphically, this scheme is defined as follows:
 
 <img src="../figures/RK2.png" align="center" width="500">
 
@@ -90,10 +90,10 @@ In notebook 1.1, we discussed the fact that the forward Euler method is second-o
 \begin{align}
  y^{n+1} & = y^n + dt f(t^n+\frac{dt}{2},y^n + \frac{dt}{2}f(t^n, y^n)) \nonumber \\
          & = y^n + dt \left[ f(t^n, y^n) + \frac{dt}{2} \partial_t f(t^n, y^n) + \frac{dt}{2} f(t^n, y^n)\partial_y f(t^n,y^n) + O(dt^2) \right] \nonumber \\
-         & = y^n + dt y^{'n} + \frac{dt^2}{2}y^{''n} + O(dt^3), \label{TaylorRK2}
+         & = y^n + dt y'^n + \frac{dt^2}{2}y''^n + O(dt^3), \label{TaylorRK2}
 \end{align}
 
-where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
+where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third-order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
 
 ### Numerical stability of a two-stage Runge-Kutta scheme
 
@@ -111,7 +111,7 @@ Using the two-stage Runge-Kutta scheme, we then have,
     z^{n} = (I+ dt \Lambda + \frac{dt^2}{2}\Lambda^2) z^{n-1} \; \Leftrightarrow \; z^{n} = (I+ dt \Lambda + \frac{dt^2}{2}\Lambda^2)^n z^0.
 \end{equation}
 
-All the components of $z^{n}$ will remain finite for $n\rightarrow \infty$ as long, as the following relation is satisified for all the eigenvalues $\lambda_k$:
+All the components of $z^{n}$ will remain finite for $n\rightarrow \infty$ as long as the following relation is satisified for all the eigenvalues $\lambda_k$:
 
 \begin{equation}
     \vert 1+\lambda_k dt + \frac{\lambda_k^2 dt^2}{2} \vert \leq 1.
@@ -273,7 +273,7 @@ For an autonomous linear system, it is straightforward to prove that this method
   & = z^n + dt \Lambda z^n + \frac{dt^2}{2}\Lambda^2 z^n + \frac{dt^3}6 \Lambda^3 z^n + \frac{dt^4}{24} \Lambda^4 z^n
 \end{align}
 
-The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth order. For a non-linear system, one can also prove that RK4 is of fourth order but it is a tedious task.
+The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth-order. For a non-linear system, one can also prove that RK4 is of fourth-order but it is a tedious task.
 
 In terms of stability, we also see that the RK4 method is stable for a general autonomous linear system as long as all the eigenvalues of the operator $f$ satisfy,
 
@@ -304,7 +304,7 @@ ny = 100
 # we want to put between, instead of the
 # distance between the points.
 # Also note that, while numpy.arange does
-# NOT includes the end point you pass into
+# NOT include the end point you pass into
 # the array, linspace does include it.
 #
 # For more info
@@ -357,7 +357,7 @@ norm4 = np.real(sigma4*sigma4.conj())
 fig, ax = plt.subplots(figsize=(8,8))
 
 # We shall now use the
-# matplotlib.pyplot.contour funtion.
+# matplotlib.pyplot.contour function.
 # As X and Y, we pass the mesh data. Let
 # f(x, y)=g(x, y) + C be some function
 # where C is a constant. Imagine
@@ -432,7 +432,7 @@ ax.set_title('Stability regions', x=0.7, y=1.01)
 # fig.savefig('../figures/stabilityDomains.png', dpi=300)
 ```
 
-We already pointed out that the forward Euler scheme is unstable if one of the eigenvalues of our system is purely imaginery (as in the case of the harmonic oscillator). Although the RK2 scheme's domain of stability is larger, the scheme has the same property. Of all the schemes considered so far, RK4 has a significantly larger domain of stability and, more importantly, it does englobe a part of the imaginery axis, so, it can handle problems with purely imaginery eigenvalues!
+We already pointed out that the forward Euler scheme is unstable if one of the eigenvalues of our system is purely imaginary (as in the case of the harmonic oscillator). Although the RK2 scheme's domain of stability is larger, the scheme has the same property. Of all the schemes considered so far, RK4 has a significantly larger domain of stability and, more importantly, it does englobe a part of the imaginary axis, so, it can handle problems with purely imaginary eigenvalues!
 
 ## Implicit Runge-Kutta schemes
 
@@ -445,7 +445,7 @@ Generally speaking, RK methods can be defined as follows:
 & k_i = f(t^n + c_i dt, y^n + dt\sum_{j=1}^h a_{ij} k_j).
 \end{align}
 
-For explicit RK methods one has $h=s-1$. This implies that any $k_i$ can be computed explicitely from the knowledge of the previously computed $k_j$ with $j<i$. For implicit RK methods, we have $h=s$. It mean, that for each $k_i$ we have to solve an implicit equation $k_i=f(k_1, k_2,\dots,k_i)$. We pay a price in terms of complexity (we have to invert some matrix or iteratively found a solution to the previous equation). However, implicit RK methods have better stability properties compared to explicit ones and can therefore be used for a larger set of problems.
+For explicit RK methods one has $h=s-1$. This implies that any $k_i$ can be computed explicitly from the knowledge of the previously computed $k_j$ with $j<i$. For implicit RK methods, we have $h=s$. It mean, that for each $k_i$ we have to solve an implicit equation $k_i=f(k_1, k_2,\dots,k_i)$. We pay a price in terms of complexity (we have to invert some matrix or iteratively found a solution to the previous equation). However, implicit RK methods have better stability properties compared to explicit ones and can therefore be used for a larger set of problems.
 
 As an example, let us consider some relatively simple implicit RK scheme - we went on [Wikipedia][1] and picked one named *Qin and Zhang's two-stage second-order* implicit method. It reads:
 
@@ -543,7 +543,7 @@ for axis in ax:
 
 ## Summary
 
-In this notebook we have introduced a family of Runge-Kutta explicit and implicit methods. While, we won't consider Runge-Kutta schemes of order higher than 4 in the course, we discussed the complexities one would face trying to construct equations for the coefficients $k_i$ for higher-order schemes. We also gave insight into implicit Runge-Kutta schemes and provided an implementation of Qin and Zhang's second-order implicit method.
+In this notebook we have introduced a family of Runge-Kutta explicit and implicit methods. While we won't consider Runge-Kutta schemes of order higher than 4 in the course, we discussed the complexities one would face trying to construct equations for the coefficients $k_i$ for higher-order schemes. We also gave insight into implicit Runge-Kutta schemes and provided an implementation of Qin and Zhang's second-order implicit method.
 
 With this we conclude the chapter dedicated to **Time integration**. In the following chapter we will consider the finite differences method to approximate derivatives in partial differential equations and convert them into a system of linear equations.
 
@@ -562,7 +562,7 @@ With this we conclude the chapter dedicated to **Time integration**. In the foll
 [1]: <https://en.wikipedia.org/wiki/List_of_Runge–Kutta_methods> "list of RK"
 
 
-## References
+# References
 
 (<a id="cit-Hairer1987" href="#call-Hairer1987">Hairer, Norsett <em>et al.</em>, 1987</a>) Ernst Hairer, Syvert Paul Norsett and Gerhard Wanner, ``_Solving Ordinary Differential Equations I: Nonstiff Problems: With 105 Figures_'',  1987.
 

--- a/notebooks/02_TimeIntegration/02_02_RungeKutta.md
+++ b/notebooks/02_TimeIntegration/02_02_RungeKutta.md
@@ -93,7 +93,7 @@ In notebook 1.1, we discussed the fact that the forward Euler method is second-o
          & = y^n + dt y'^n + \frac{dt^2}{2}y''^n + O(dt^3), \label{TaylorRK2}
 \end{align}
 
-where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third-order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two-stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
+where we have used the property: $y''=\partial_t f + f\partial_y f$. Eq. \ref{TaylorRK2} proves that the two-stage Runge-Kutta method is of third order for one time step and, as a consequence, it is expected to be second-order accurate for a complete time interval (we leave it as an exercise to show that this two-stage Runge-Kutta scheme does not match further the Taylor expansion of $y^{n+1}$, and is, therefore, not of higher-order accuracy).
 
 ### Numerical stability of a two-stage Runge-Kutta scheme
 
@@ -251,7 +251,7 @@ General Runge-Kutta schemes are defined as follows \cite{Hairer1987}:
 
 Some constraints are then put on all the coefficients to achieve a given order of accuracy $O(dt^p)$ for $y^{n+1}$. One says that the $s$-stage Runge-Kutta method is of order $p$.
 
-The construction of higher-order Runge-Kutta schemes is in fact quite complicated, and has been the subject of a vast literature (some in-depth review of the Runge-Kutta methods may be found in \cite{Butcher2008} or \cite{Hairer1987}). There is no systematic way to obtain order $p$ methods with a minimum number of stages $s$. One can achieve order $p$ with $s=p$ up to $p=4$. For $p=5$ and $p=6$ one needs at least $s=p+1$ stages. For $p=7$ and $p=8$ the minimum number of stages are respectively $s=9$ and $s=11$.
+The construction of higher order Runge-Kutta schemes is in fact quite complicated, and has been the subject of a vast literature (some in-depth review of the Runge-Kutta methods may be found in \cite{Butcher2008} or \cite{Hairer1987}). There is no systematic way to obtain order $p$ methods with a minimum number of stages $s$. One can achieve order $p$ with $s=p$ up to $p=4$. For $p=5$ and $p=6$ one needs at least $s=p+1$ stages. For $p=7$ and $p=8$ the minimum number of stages are respectively $s=9$ and $s=11$.
 
 > Above this, very little is known \cite{Butcher1996}.
 
@@ -273,7 +273,7 @@ For an autonomous linear system, it is straightforward to prove that this method
   & = z^n + dt \Lambda z^n + \frac{dt^2}{2}\Lambda^2 z^n + \frac{dt^3}6 \Lambda^3 z^n + \frac{dt^4}{24} \Lambda^4 z^n
 \end{align}
 
-The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth-order. For a non-linear system, one can also prove that RK4 is of fourth-order but it is a tedious task.
+The last expression coincides with the Taylor expansion of $z^{n+1}$ up to fourth order. For a non-linear system, one can also prove that RK4 is of fourth-order but it is a tedious task.
 
 In terms of stability, we also see that the RK4 method is stable for a general autonomous linear system as long as all the eigenvalues of the operator $f$ satisfy,
 
@@ -562,7 +562,7 @@ With this we conclude the chapter dedicated to **time integration**. In the foll
 [1]: <https://en.wikipedia.org/wiki/List_of_Runge–Kutta_methods> "list of RK"
 
 
-# References
+## References
 
 (<a id="cit-Hairer1987" href="#call-Hairer1987">Hairer, Norsett <em>et al.</em>, 1987</a>) Ernst Hairer, Syvert Paul Norsett and Gerhard Wanner, ``_Solving Ordinary Differential Equations I: Nonstiff Problems: With 105 Figures_'',  1987.
 


### PR DESCRIPTION
Also moved the primes outside the exponent in equation (5) to make them more visible as primes (possible confusion with a 'n')